### PR TITLE
Fix invalid resource environment (missing IDs for CPU)

### DIFF
--- a/LinkingResource_Test/default.measuringpoint
+++ b/LinkingResource_Test/default.measuringpoint
@@ -8,11 +8,11 @@
     <operationSignature href="default.repository#_tgOHUQm1EeCni99i-bbseA"/>
     <system href="default.system#_oZYAgB_dEd-CePn_osfrtQ"/>
   </measuringPoints>
-  <measuringPoints xsi:type="pcmmeasuringpoint:ActiveResourceMeasuringPoint" stringRepresentation="CPU [0] in pc1" resourceURIRepresentation="platform:/resource/LinkingResourceTest/default.resourceenvironment#_UC1UJLerEeqCx9D3JGHCDw">
-    <activeResource href="default.resourceenvironment#_UC1UJLerEeqCx9D3JGHCDw"/>
+  <measuringPoints xsi:type="pcmmeasuringpoint:ActiveResourceMeasuringPoint" stringRepresentation="CPU [0] in pc1" resourceURIRepresentation="platform:/resource/LinkingResourceTest/default.resourceenvironment#_G1w5wxg-EeuyYLZl5_e8mw">
+    <activeResource href="default.resourceenvironment#_G1w5wxg-EeuyYLZl5_e8mw"/>
   </measuringPoints>
-  <measuringPoints xsi:type="pcmmeasuringpoint:ActiveResourceMeasuringPoint" stringRepresentation="CPU [0] in pc2" resourceURIRepresentation="platform:/resource/LinkingResourceTest/default.resourceenvironment#_UC1UKLerEeqCx9D3JGHCDw">
-    <activeResource href="default.resourceenvironment#_UC1UKLerEeqCx9D3JGHCDw"/>
+  <measuringPoints xsi:type="pcmmeasuringpoint:ActiveResourceMeasuringPoint" stringRepresentation="CPU [0] in pc2" resourceURIRepresentation="platform:/resource/LinkingResourceTest/default.resourceenvironment#_G1w5xxg-EeuyYLZl5_e8mw">
+    <activeResource href="default.resourceenvironment#_G1w5xxg-EeuyYLZl5_e8mw"/>
   </measuringPoints>
   <measuringPoints xsi:type="pcmmeasuringpoint:UsageScenarioMeasuringPoint" stringRepresentation="Usage Scenario: defaultUsageScenario" resourceURIRepresentation="platform:/resource/LinkingResourceTest/default.usagemodel#_N1WSwB_eEd-CePn_osfrtQ">
     <usageScenario href="default.usagemodel#_N1WSwB_eEd-CePn_osfrtQ"/>

--- a/LinkingResource_Test/default.resourceenvironment
+++ b/LinkingResource_Test/default.resourceenvironment
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ResourceEnvironment xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns="http://palladiosimulator.org/PalladioComponentModel/ResourceEnvironment/5.2">
+<resourceenvironment:ResourceEnvironment xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:resourceenvironment="http://palladiosimulator.org/PalladioComponentModel/ResourceEnvironment/5.2">
   <linkingResources__ResourceEnvironment id="_xyMKAB_dEd-CePn_osfrtQ" connectedResourceContainers_LinkingResource="_wShuEB_dEd-CePn_osfrtQ _vpZRgB_dEd-CePn_osfrtQ _vpZRgB_dEd-CePn_osfrtQ _wShuEB_dEd-CePn_osfrtQ">
     <communicationLinkResourceSpecifications_LinkingResource id="_D2tBIQm2EeCni99i-bbseA">
       <communicationLinkResourceType_CommunicationLinkResourceSpecification href="pathmap://PCM_MODELS/Palladio.resourcetype#_o3sScH2AEdyH8uerKnHYug"/>
@@ -8,15 +8,17 @@
     </communicationLinkResourceSpecifications_LinkingResource>
   </linkingResources__ResourceEnvironment>
   <resourceContainer_ResourceEnvironment id="_vpZRgB_dEd-CePn_osfrtQ" entityName="pc1">
-    <activeResourceSpecifications_ResourceContainer > <schedulingPolicy href="pathmap://PCM_MODELS/Palladio.resourcetype#ProcessorSharing"/>
+    <activeResourceSpecifications_ResourceContainer id="_G1w5wxg-EeuyYLZl5_e8mw">
+      <schedulingPolicy href="pathmap://PCM_MODELS/Palladio.resourcetype#ProcessorSharing"/>
       <activeResourceType_ActiveResourceSpecification href="pathmap://PCM_MODELS/Palladio.resourcetype#_oro4gG3fEdy4YaaT-RYrLQ"/>
       <processingRate_ProcessingResourceSpecification specification="1000"/>
     </activeResourceSpecifications_ResourceContainer>
   </resourceContainer_ResourceEnvironment>
   <resourceContainer_ResourceEnvironment id="_wShuEB_dEd-CePn_osfrtQ" entityName="pc2">
-    <activeResourceSpecifications_ResourceContainer > <schedulingPolicy href="pathmap://PCM_MODELS/Palladio.resourcetype#ProcessorSharing"/>
+    <activeResourceSpecifications_ResourceContainer id="_G1w5xxg-EeuyYLZl5_e8mw">
+      <schedulingPolicy href="pathmap://PCM_MODELS/Palladio.resourcetype#ProcessorSharing"/>
       <activeResourceType_ActiveResourceSpecification href="pathmap://PCM_MODELS/Palladio.resourcetype#_oro4gG3fEdy4YaaT-RYrLQ"/>
       <processingRate_ProcessingResourceSpecification specification="1000"/>
     </activeResourceSpecifications_ResourceContainer>
   </resourceContainer_ResourceEnvironment>
-</ResourceEnvironment>
+</resourceenvironment:ResourceEnvironment>

--- a/LinkingResource_Test/default.system
+++ b/LinkingResource_Test/default.system
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<System xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://palladiosimulator.org/PalladioComponentModel/System/5.2" xmlns:composition="http://palladiosimulator.org/PalladioComponentModel/Core/Composition/5.2" xmlns:_1="http://palladiosimulator.org/PalladioComponentModel/Repository/5.2" id="_oZYAgB_dEd-CePn_osfrtQ" entityName="defaultSystem">
+<system:System xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:composition="http://palladiosimulator.org/PalladioComponentModel/Core/Composition/5.2" xmlns:repository="http://palladiosimulator.org/PalladioComponentModel/Repository/5.2" xmlns:system="http://palladiosimulator.org/PalladioComponentModel/System/5.2" id="_oZYAgB_dEd-CePn_osfrtQ" entityName="defaultSystem">
   <assemblyContexts__ComposedStructure id="_rDQM0B_dEd-CePn_osfrtQ" entityName="Assembly_C1 &lt;C1>">
-    <encapsulatedComponent__AssemblyContext xsi:type="_1:BasicComponent" href="default.repository#_j_LuwAv1Ed-gn68C3sIQfQ"/>
+    <encapsulatedComponent__AssemblyContext xsi:type="repository:BasicComponent" href="default.repository#_j_LuwAv1Ed-gn68C3sIQfQ"/>
   </assemblyContexts__ComposedStructure>
   <assemblyContexts__ComposedStructure id="_rqvDkB_dEd-CePn_osfrtQ" entityName="Assembly_C2 &lt;C2>">
-    <encapsulatedComponent__AssemblyContext xsi:type="_1:BasicComponent" href="default.repository#__-EPUB_cEd-CePn_osfrtQ"/>
+    <encapsulatedComponent__AssemblyContext xsi:type="repository:BasicComponent" href="default.repository#__-EPUB_cEd-CePn_osfrtQ"/>
   </assemblyContexts__ComposedStructure>
   <connectors__ComposedStructure xsi:type="composition:ProvidedDelegationConnector" id="_si6owB_dEd-CePn_osfrtQ" entityName="ProvDelegation Provided_Ieins -> Provided_Ieins_aName" outerProvidedRole_ProvidedDelegationConnector="_pUFVQB_dEd-CePn_osfrtQ" assemblyContext_ProvidedDelegationConnector="_rDQM0B_dEd-CePn_osfrtQ">
     <innerProvidedRole_ProvidedDelegationConnector href="default.repository#_6T0pUB_cEd-CePn_osfrtQ"/>
@@ -13,7 +13,7 @@
     <providedRole_AssemblyConnector href="default.repository#_AupXsB_dEd-CePn_osfrtQ"/>
     <requiredRole_AssemblyConnector href="default.repository#_BcGTkB_dEd-CePn_osfrtQ"/>
   </connectors__ComposedStructure>
-  <providedRoles_InterfaceProvidingEntity xsi:type="_1:OperationProvidedRole" id="_pUFVQB_dEd-CePn_osfrtQ" entityName="Provided_Ieins">
+  <providedRoles_InterfaceProvidingEntity xsi:type="repository:OperationProvidedRole" id="_pUFVQB_dEd-CePn_osfrtQ" entityName="Provided_Ieins">
     <providedInterface__OperationProvidedRole href="default.repository#_js2ooAv1Ed-gn68C3sIQfQ"/>
   </providedRoles_InterfaceProvidingEntity>
-</System>
+</system:System>

--- a/LinkingResource_Test/default.usagemodel
+++ b/LinkingResource_Test/default.usagemodel
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<UsageModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://palladiosimulator.org/PalladioComponentModel/UsageModel/5.2">
+<usagemodel:UsageModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:usagemodel="http://palladiosimulator.org/PalladioComponentModel/UsageModel/5.2">
   <usageScenario_UsageModel id="_N1WSwB_eEd-CePn_osfrtQ" entityName="defaultUsageScenario">
-    <workload_UsageScenario xsi:type="ClosedWorkload" population="1">
-      <thinkTime_ClosedWorkload specification="0.0"/>
-    </workload_UsageScenario>
     <scenarioBehaviour_UsageScenario id="_N1WSwR_eEd-CePn_osfrtQ" entityName="defaultUsageScenarioBehaviour">
-      <actions_ScenarioBehaviour xsi:type="Start" id="_N1WSwh_eEd-CePn_osfrtQ" successor="_Qt-FsB_eEd-CePn_osfrtQ"/>
-      <actions_ScenarioBehaviour xsi:type="Stop" id="_N1WSwx_eEd-CePn_osfrtQ" predecessor="_Qt-FsB_eEd-CePn_osfrtQ"/>
-      <actions_ScenarioBehaviour xsi:type="EntryLevelSystemCall" id="_Qt-FsB_eEd-CePn_osfrtQ" successor="_N1WSwx_eEd-CePn_osfrtQ" predecessor="_N1WSwh_eEd-CePn_osfrtQ">
+      <actions_ScenarioBehaviour xsi:type="usagemodel:Start" id="_N1WSwh_eEd-CePn_osfrtQ" successor="_Qt-FsB_eEd-CePn_osfrtQ"/>
+      <actions_ScenarioBehaviour xsi:type="usagemodel:Stop" id="_N1WSwx_eEd-CePn_osfrtQ" predecessor="_Qt-FsB_eEd-CePn_osfrtQ"/>
+      <actions_ScenarioBehaviour xsi:type="usagemodel:EntryLevelSystemCall" id="_Qt-FsB_eEd-CePn_osfrtQ" successor="_N1WSwx_eEd-CePn_osfrtQ" predecessor="_N1WSwh_eEd-CePn_osfrtQ">
         <providedRole_EntryLevelSystemCall href="default.system#_pUFVQB_dEd-CePn_osfrtQ"/>
-        <operationSignature__EntryLevelSystemCall href="default.repository#//@interfaces__Repository.0/@signatures__OperationInterface.0"/>
+        <operationSignature__EntryLevelSystemCall href="default.repository#_tgOHUQm1EeCni99i-bbseA"/>
       </actions_ScenarioBehaviour>
     </scenarioBehaviour_UsageScenario>
+    <workload_UsageScenario xsi:type="usagemodel:ClosedWorkload" population="1">
+      <thinkTime_ClosedWorkload specification="0.0"/>
+    </workload_UsageScenario>
   </usageScenario_UsageModel>
-</UsageModel>
+</usagemodel:UsageModel>

--- a/LinkingResource_Test/representations.aird
+++ b/LinkingResource_Test/representations.aird
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:allocation="http://palladiosimulator.org/PalladioComponentModel/Allocation/5.2" xmlns:composition="http://palladiosimulator.org/PalladioComponentModel/Core/Composition/5.2" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:diagram="http://www.eclipse.org/sirius/diagram/1.1.0" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:parameter="http://palladiosimulator.org/PalladioComponentModel/Parameter/5.2" xmlns:repository="http://palladiosimulator.org/PalladioComponentModel/Repository/5.2" xmlns:resourceenvironment="http://palladiosimulator.org/PalladioComponentModel/ResourceEnvironment/5.2" xmlns:seff="http://palladiosimulator.org/PalladioComponentModel/SEFF/5.2" xmlns:seff_performance="http://palladiosimulator.org/PalladioComponentModel/SEFF/SEFF_Performance/5.2" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:system="http://palladiosimulator.org/PalladioComponentModel/System/5.2" xmlns:usagemodel="http://palladiosimulator.org/PalladioComponentModel/UsageModel/5.2" xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0" xsi:schemaLocation="http://palladiosimulator.org/PalladioComponentModel/Allocation/5.2 http://palladiosimulator.org/PalladioComponentModel/5.2#//allocation http://palladiosimulator.org/PalladioComponentModel/Core/Composition/5.2 http://palladiosimulator.org/PalladioComponentModel/5.2#//core/composition http://www.eclipse.org/sirius/description/1.1.0 http://www.eclipse.org/sirius/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description http://palladiosimulator.org/PalladioComponentModel/Parameter/5.2 http://palladiosimulator.org/PalladioComponentModel/5.2#//parameter http://palladiosimulator.org/PalladioComponentModel/Repository/5.2 http://palladiosimulator.org/PalladioComponentModel/5.2#//repository http://palladiosimulator.org/PalladioComponentModel/ResourceEnvironment/5.2 http://palladiosimulator.org/PalladioComponentModel/5.2#//resourceenvironment http://palladiosimulator.org/PalladioComponentModel/SEFF/5.2 http://palladiosimulator.org/PalladioComponentModel/5.2#//seff http://palladiosimulator.org/PalladioComponentModel/SEFF/SEFF_Performance/5.2 http://palladiosimulator.org/PalladioComponentModel/5.2#//seff/seff_performance http://www.eclipse.org/sirius/diagram/description/style/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/style http://palladiosimulator.org/PalladioComponentModel/System/5.2 http://palladiosimulator.org/PalladioComponentModel/5.2#//system http://palladiosimulator.org/PalladioComponentModel/UsageModel/5.2 http://palladiosimulator.org/PalladioComponentModel/5.2#//usagemodel">
-  <viewpoint:DAnalysis uid="_u7tPwDcXEee78-rIUlpnPg" selectedViews="_5W3AADcXEee78-rIUlpnPg _5YUYkDcXEee78-rIUlpnPg _5ZYvkDcXEee78-rIUlpnPg _5ae7wDcXEee78-rIUlpnPg _5bH08DcXEee78-rIUlpnPg _5eIssDcXEee78-rIUlpnPg" version="14.1.0.201810161215">
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:allocation="http://palladiosimulator.org/PalladioComponentModel/Allocation/5.2" xmlns:composition="http://palladiosimulator.org/PalladioComponentModel/Core/Composition/5.2" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:diagram="http://www.eclipse.org/sirius/diagram/1.1.0" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.3/notation" xmlns:parameter="http://palladiosimulator.org/PalladioComponentModel/Parameter/5.2" xmlns:repository="http://palladiosimulator.org/PalladioComponentModel/Repository/5.2" xmlns:resourceenvironment="http://palladiosimulator.org/PalladioComponentModel/ResourceEnvironment/5.2" xmlns:seff="http://palladiosimulator.org/PalladioComponentModel/SEFF/5.2" xmlns:seff_performance="http://palladiosimulator.org/PalladioComponentModel/SEFF/SEFF_Performance/5.2" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:system="http://palladiosimulator.org/PalladioComponentModel/System/5.2" xmlns:usagemodel="http://palladiosimulator.org/PalladioComponentModel/UsageModel/5.2" xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0" xsi:schemaLocation="http://palladiosimulator.org/PalladioComponentModel/Allocation/5.2 http://palladiosimulator.org/PalladioComponentModel/5.2#//allocation http://palladiosimulator.org/PalladioComponentModel/Core/Composition/5.2 http://palladiosimulator.org/PalladioComponentModel/5.2#//core/composition http://www.eclipse.org/sirius/description/1.1.0 http://www.eclipse.org/sirius/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description http://palladiosimulator.org/PalladioComponentModel/Parameter/5.2 http://palladiosimulator.org/PalladioComponentModel/5.2#//parameter http://palladiosimulator.org/PalladioComponentModel/Repository/5.2 http://palladiosimulator.org/PalladioComponentModel/5.2#//repository http://palladiosimulator.org/PalladioComponentModel/ResourceEnvironment/5.2 http://palladiosimulator.org/PalladioComponentModel/5.2#//resourceenvironment http://palladiosimulator.org/PalladioComponentModel/SEFF/5.2 http://palladiosimulator.org/PalladioComponentModel/5.2#//seff http://palladiosimulator.org/PalladioComponentModel/SEFF/SEFF_Performance/5.2 http://palladiosimulator.org/PalladioComponentModel/5.2#//seff/seff_performance http://www.eclipse.org/sirius/diagram/description/style/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/style http://palladiosimulator.org/PalladioComponentModel/System/5.2 http://palladiosimulator.org/PalladioComponentModel/5.2#//system http://palladiosimulator.org/PalladioComponentModel/UsageModel/5.2 http://palladiosimulator.org/PalladioComponentModel/5.2#//usagemodel">
+  <viewpoint:DAnalysis uid="_u7tPwDcXEee78-rIUlpnPg" selectedViews="_5W3AADcXEee78-rIUlpnPg _5YUYkDcXEee78-rIUlpnPg _5ZYvkDcXEee78-rIUlpnPg _5ae7wDcXEee78-rIUlpnPg _5bH08DcXEee78-rIUlpnPg _5eIssDcXEee78-rIUlpnPg" version="14.3.1.202003261200">
     <semanticResources>default.allocation</semanticResources>
     <semanticResources>default.resourceenvironment</semanticResources>
     <semanticResources>default.system</semanticResources>
@@ -60,7 +60,7 @@
       </ownedRepresentationDescriptors>
     </ownedViews>
   </viewpoint:DAnalysis>
-  <diagram:DSemanticDiagram uid="_5X7XATcXEee78-rIUlpnPg" name="Allocation Diagram">
+  <diagram:DSemanticDiagram uid="_5X7XATcXEee78-rIUlpnPg">
     <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_5X7XAjcXEee78-rIUlpnPg" source="DANNOTATION_CUSTOMIZATION_KEY">
       <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_5X7XAzcXEee78-rIUlpnPg"/>
     </ownedAnnotationEntries>
@@ -142,7 +142,7 @@
     <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.palladiosimulator.editors.sirius.allocation/description/allocation.odesign#//@ownedViewpoints[name='Allocation']/@ownedRepresentations[name='Allocation%20Diagram']/@defaultLayer"/>
     <target xmi:type="allocation:Allocation" href="default.allocation#_HNGzcB_eEd-CePn_osfrtQ"/>
   </diagram:DSemanticDiagram>
-  <diagram:DSemanticDiagram uid="_5ZHCwTcXEee78-rIUlpnPg" name="UsageModel Diagram">
+  <diagram:DSemanticDiagram uid="_5ZHCwTcXEee78-rIUlpnPg">
     <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_5ZHCwjcXEee78-rIUlpnPg" source="DANNOTATION_CUSTOMIZATION_KEY">
       <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_5ZHCwzcXEee78-rIUlpnPg"/>
     </ownedAnnotationEntries>
@@ -346,7 +346,7 @@
     <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.palladiosimulator.editors.sirius.usage/description/usage.odesign#//@ownedViewpoints[name='UsageModel']/@ownedRepresentations[name='UsageModel%20Diagram']/@defaultLayer"/>
     <target xmi:type="usagemodel:UsageModel" href="default.usagemodel#/"/>
   </diagram:DSemanticDiagram>
-  <diagram:DSemanticDiagram uid="_5ZoAITcXEee78-rIUlpnPg" name="Seff Diagram">
+  <diagram:DSemanticDiagram uid="_5ZoAITcXEee78-rIUlpnPg">
     <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_5ZoAIjcXEee78-rIUlpnPg" source="DANNOTATION_CUSTOMIZATION_KEY">
       <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_5ZoAIzcXEee78-rIUlpnPg"/>
     </ownedAnnotationEntries>
@@ -695,7 +695,7 @@
     <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.palladiosimulator.editors.sirius.seff/description/seff.odesign#//@ownedViewpoints[name='Seff']/@ownedRepresentations[name='Seff%20Diagram']/@defaultLayer"/>
     <target xmi:type="seff:ResourceDemandingSEFF" href="default.repository#_CoPWkB_dEd-CePn_osfrtQ"/>
   </diagram:DSemanticDiagram>
-  <diagram:DSemanticDiagram uid="_5aKLoTcXEee78-rIUlpnPg" name="Seff Diagram">
+  <diagram:DSemanticDiagram uid="_5aKLoTcXEee78-rIUlpnPg">
     <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_5aKLojcXEee78-rIUlpnPg" source="DANNOTATION_CUSTOMIZATION_KEY">
       <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_5aKLozcXEee78-rIUlpnPg"/>
     </ownedAnnotationEntries>
@@ -967,7 +967,7 @@
     <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.palladiosimulator.editors.sirius.seff/description/seff.odesign#//@ownedViewpoints[name='Seff']/@ownedRepresentations[name='Seff%20Diagram']/@defaultLayer"/>
     <target xmi:type="seff:ResourceDemandingSEFF" href="default.repository#_CELnQB_dEd-CePn_osfrtQ"/>
   </diagram:DSemanticDiagram>
-  <diagram:DSemanticDiagram uid="_5as-MTcXEee78-rIUlpnPg" name="ResourceEnvironment Diagram">
+  <diagram:DSemanticDiagram uid="_5as-MTcXEee78-rIUlpnPg">
     <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_5atlQDcXEee78-rIUlpnPg" source="DANNOTATION_CUSTOMIZATION_KEY">
       <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_5atlQTcXEee78-rIUlpnPg"/>
     </ownedAnnotationEntries>
@@ -1288,7 +1288,7 @@
     <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.palladiosimulator.editors.sirius.resourceenvironment/description/resourceenvironment.odesign#//@ownedViewpoints[name='ResourceEnvironment']/@ownedRepresentations[name='ResourceEnvironment%20Diagram']/@defaultLayer"/>
     <target xmi:type="resourceenvironment:ResourceEnvironment" href="default.resourceenvironment#/"/>
   </diagram:DSemanticDiagram>
-  <diagram:DSemanticDiagram uid="_5dvEEDcXEee78-rIUlpnPg" name="Assembly Diagram">
+  <diagram:DSemanticDiagram uid="_5dvEEDcXEee78-rIUlpnPg">
     <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_5dvEETcXEee78-rIUlpnPg" source="DANNOTATION_CUSTOMIZATION_KEY">
       <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_5dvEEjcXEee78-rIUlpnPg"/>
     </ownedAnnotationEntries>
@@ -1495,7 +1495,7 @@
     <activatedLayers xmi:type="description_1:AdditionalLayer" href="platform:/plugin/org.palladiosimulator.editors.sirius.assembly/description/assembly.odesign#//@ownedViewpoints[name='Assembly']/@ownedRepresentations[name='Assembly%20Diagram']/@additionalLayers[name='QoS']"/>
     <target xmi:type="system:System" href="default.system#_oZYAgB_dEd-CePn_osfrtQ"/>
   </diagram:DSemanticDiagram>
-  <diagram:DSemanticDiagram uid="_5fglsDcXEee78-rIUlpnPg" name="Repository Diagram">
+  <diagram:DSemanticDiagram uid="_5fglsDcXEee78-rIUlpnPg">
     <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_5fglsTcXEee78-rIUlpnPg" source="DANNOTATION_CUSTOMIZATION_KEY">
       <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_5fglsjcXEee78-rIUlpnPg"/>
     </ownedAnnotationEntries>
@@ -1917,7 +1917,7 @@
     <activatedLayers xmi:type="description_1:AdditionalLayer" href="platform:/plugin/org.palladiosimulator.editors.sirius.repository/description/repository.odesign#//@ownedViewpoints[name='Repository']/@ownedRepresentations[name='Repository%20Diagram']/@additionalLayers[name='DataTypes']"/>
     <target xmi:type="repository:Repository" href="default.repository#_nWy_oAnYEd-sJ-cVQCq7bg"/>
   </diagram:DSemanticDiagram>
-  <diagram:DSemanticDiagram uid="_5fq9wTcXEee78-rIUlpnPg" name="Repository Diagram">
+  <diagram:DSemanticDiagram uid="_5fq9wTcXEee78-rIUlpnPg">
     <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_5fq9wjcXEee78-rIUlpnPg" source="DANNOTATION_CUSTOMIZATION_KEY">
       <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_5fq9wzcXEee78-rIUlpnPg"/>
     </ownedAnnotationEntries>


### PR DESCRIPTION
This PR fixes the Linking Resource Test example. The Measuring Point model was invalid, as it was refering to CPUs in the Resource Environment which were serialized without IDs. Consequently, the CPUs had ids generated anew everytime the model was loaded.

This should be fixed now. 